### PR TITLE
Fix A/B test indentation

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1398,8 +1398,6 @@ elif page == "🤖 AI Agents":
                             st.session_state.agents[selected_agent]['prompt'] = test_prompt
                             st.success("✅ Agent updated with new prompt!")
                             st.rerun()
-                    st.success("✅ Agent updated with new prompt!")
-                            st.rerun()
     
     with tabs[3]:
         st.markdown("### Agent Performance Analytics")


### PR DESCRIPTION
## Summary
- remove stray lines after A/B test completion prompt that caused an
  `IndentationError`

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844799008a88333b67190305e2e0f85